### PR TITLE
Use `uuid-random` to support platforms without `crypto`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.15",
-    "uuid": "^3.3.3"
+    "uuid-random": "^1.3.2"
   },
   "devDependencies": {
     "@rollup/plugin-json": "^4.0.0",

--- a/src/lib/CharacterCreator.ts
+++ b/src/lib/CharacterCreator.ts
@@ -1,4 +1,4 @@
-import { v4 as uuid } from 'uuid';
+import * as uuid from 'uuid-random';
 
 import { cloneDeep, round } from 'lodash';
 import { IAction } from './interfaces/IAction';

--- a/src/lib/WyrmEngine.ts
+++ b/src/lib/WyrmEngine.ts
@@ -1,4 +1,4 @@
-import { v4 as uuid } from 'uuid';
+import * as uuid from 'uuid-random';
 
 import { IEcounterLog, IEngineCharacter } from '.';
 import { CharacterCreator } from './CharacterCreator';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4349,7 +4349,12 @@ util.promisify@^1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
-uuid@^3.3.2, uuid@^3.3.3:
+uuid-random@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/uuid-random/-/uuid-random-1.3.2.tgz#96715edbaef4e84b1dcf5024b00d16f30220e2d0"
+  integrity sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ==
+
+uuid@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==


### PR DESCRIPTION
This makes it possible to use wyrm-engine in a non-node environment.